### PR TITLE
`pre-commit`: configure CI settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,11 @@
 #   where {files} is the regex of files to process, & {exclude} is the regex of
 #   files to exclude.
 
+# https://pre-commit.ci/ configuration
+ci:
+  autofix_prs: true
+  autoupdate_schedule: monthly
+
 repos:
   # Pre-commit's built-in collection
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
see https://pre-commit.ci/#configuration for more context, but here are updates:
- don't auto-fix PRs; this gets messy if I have multiple PRs stacked on top of each other (e.g. via Graphite), because all PRs on top of a "broken" PR get an auto-fix commit, which is undesired
- update auto-update schedule to monthly instead of the default weekly